### PR TITLE
Add workaround for ASI in list/dict literals

### DIFF
--- a/nolang/lexer.py
+++ b/nolang/lexer.py
@@ -259,7 +259,9 @@ class QuillLexer(object):
         return self.states[name]
 
     def lex(self, filename, s):
-        return QuillLexerStream(self, filename, s)
+        for item in QuillLexerStream(self, filename, s):
+            print item
+            yield item
 
 
 class LexerState(object):

--- a/nolang/parser.py
+++ b/nolang/parser.py
@@ -493,10 +493,14 @@ def get_parser():
     def atom_dot_identifier(state, p):
         return ast.Getattr(p[0], p[2].getstr(), srcpos=sr(p))
 
+    # permit a trailing semicolon in the list to work around ASI putting one there
+    @pg.production('atom : LEFT_SQUARE_BRACKET expression_list SEMICOLON RIGHT_SQUARE_BRACKET')
     @pg.production('atom : LEFT_SQUARE_BRACKET expression_list RIGHT_SQUARE_BRACKET')
     def atom_list_literal(state, p):
         return ast.List(p[1].get_element_list(), srcpos=sr(p))
 
+    # permit a trailing semicolon in the dict to work around ASI putting one there
+    @pg.production('atom : LEFT_CURLY_BRACE dict_pair_list SEMICOLON RIGHT_CURLY_BRACE')
     @pg.production('atom : LEFT_CURLY_BRACE dict_pair_list RIGHT_CURLY_BRACE')
     def atom_dict_literal(state, p):
         return ast.Dict(p[1].get_element_list(), srcpos=sr(p))

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -72,8 +72,11 @@ class TestDict(BaseTest):
 
     def test_setitem(self):
         w_res = self.interpret_expr('''
-            var x;
-            x = {"a": "foo", 1: "bar"};
+            var x
+            x = {
+                "a": "foo",
+                1: "bar"
+            };
             x["c"] = "baz";
             return x;
         ''')

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -148,7 +148,10 @@ class TestList(BaseTest):
             def main() {
                 var l;
                 l = [];
-                [check(l, 0), check(l, 1)];
+                [
+                    check(l, 0),
+                    check(l, 1)
+                ];
                 return l;
             }
         ''')


### PR DESCRIPTION
This adds a rule to support a semicolon at the end of a dict or list
literal so that the closing paren can be placed on a different line.